### PR TITLE
Add final Android button example improvements

### DIFF
--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -13,7 +13,7 @@ There are four types of buttons:
 
 ## Using buttons
 
-Before you can use the Material.io button, you need to add a dependency to the Material Components for Android library. For more information, go to the [Getting started](https://github.com/material-components/material-components-android/blob/master/docs/getting-started.md) page.
+Before you can use Material buttons, you need to add a dependency to the Material Components for Android library. For more information, go to the [Getting started](https://github.com/material-components/material-components-android/blob/master/docs/getting-started.md) page.
 
 ## Text button
 

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -81,7 +81,6 @@ Source code API:
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
-
 The following example shows a contained button with a text label and a filled container.
 
 !["Contained button example for Android with the white text 'Text' on a purple background."](assets/contained-button.svg)
@@ -101,15 +100,15 @@ The following example shows a contained button with a text label and a filled co
 
 [Toggle buttons](https://material.io/components/buttons/#toggle-button) can be used to select from a group of choices.
 
-The toggle button can be separated into two types:
-* [Toggle bar](#toggle-bar)
-* [Toggle icon button](#toggle-icon-button)
+Toggle buttons can be separated into two types:
+* [Toggle button](#toggle-button)
+* [Icon](#icon)
 
-### Toggle Bar
+### Toggle button
 
-The toggle bar is a group of related toggle buttons sharing a common container.
+To emphasize groups of related toggle buttons, a group should share a common container.
 
-#### Toggle bar example
+#### Toggle button example
 
 The following example shows a toggle bar with the following icons:
 * aspect ratio
@@ -130,7 +129,6 @@ Source code APIs:
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java)
 
 !["Toggle bar example for Android displaying icons."](assets/toggle-buttons.svg)
-
 
 ```xml
  <com.google.android.material.button.MaterialButtonToggleGroup
@@ -162,14 +160,11 @@ Source code APIs:
 
 ```
 
+### Icon
 
-### Toggle icon button
+Icons can be used as toggle buttons when they allow selection, or deselection, of a single choice, such as marking an item as a favorite.
 
-
-The toggle icon button allows you to select from a group using an icon.
-
-
-#### Toggle icon button example
+#### Icon example
 
 Source code APIs:
 
@@ -270,5 +265,3 @@ In the `actvity_main.xml` file, the list of images in arranged to fit into the `
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 ```
-
-

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -5,9 +5,9 @@
 There are four types of buttons:
 
 1. [Text button](#text-button)
-1. [Outlined button](#outlined-button)
-1. [Contained button](#contained-button)
-1. [Toggle button](#toggle-button)
+2. [Outlined button](#outlined-button)
+3. [Contained button](#contained-button)
+4. [Toggle button](#toggle-button)
 
 ![Example of the four button types](assets/button-types.svg)
 
@@ -100,7 +100,8 @@ The following example shows a contained button with a text label and a filled co
 
 [Toggle buttons](https://material.io/components/buttons/#toggle-button) can be used to select from a group of choices.
 
-Toggle buttons can be separated into two types:
+There are two types of toggle buttons:
+
 * [Toggle button](#toggle-button)
 * [Icon](#icon)
 

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -27,7 +27,7 @@ Source code API:
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
-The following example shows a text button with purple text on a white background.
+The following example shows a text button with a text label.
 
 !["Text button example for Android with purple text 'Text' over a white background."](assets/text-button.svg)
 
@@ -53,6 +53,8 @@ Source code API:
 * `MaterialButton`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
+    
+The following example shows an outlined button with a text label and stroked container.    
 
 !["Outlined button example in Android with purple text surrounded by a gray outline"](assets/outlined-button.svg)
 
@@ -80,7 +82,7 @@ Source code API:
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
 
-The following example shows a contained button with white text on a purple background.
+The following example shows a contained button with a text label and a filled container.
 
 !["Contained button example for Android with the white text 'Text' on a purple background."](assets/contained-button.svg)
 

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -23,7 +23,7 @@ Before you can use Material buttons, you need to add a dependency to the Materia
 
 Source code API:
 
-* MaterialButton
+* `MaterialButton`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
@@ -50,7 +50,7 @@ The following example shows a text button with purple text on a white background
 
 Source code API:
 
-* MaterialButton
+* `MaterialButton`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
@@ -75,7 +75,7 @@ Source code API:
 
 Source code API:
 
-* MaterialButton
+* `MaterialButton`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
@@ -120,11 +120,11 @@ The example allows multiple buttons to be selected. If only one option in the gr
 
 Source code APIs:
 
-* MaterialButton
+* `MaterialButton`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
-* MaterialButtonToggleGroup
+* `MaterialButtonToggleGroup`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButtonToggleGroup)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java)
 
@@ -172,10 +172,10 @@ The toggle icon button allows you to select from a group using an icon.
 
 Source code APIs:
 
-* [RecyclerView](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView)
-* [FrameLayout](https://developer.android.com/reference/android/widget/FrameLayout)
-* [ImageView](https://developer.android.com/reference/android/widget/ImageView)
-* [CheckBox](https://developer.android.com/reference/android/widget/CheckBox)
+* [`RecyclerView`](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView)
+* [`FrameLayout`](https://developer.android.com/reference/android/widget/FrameLayout)
+* [`ImageView`](https://developer.android.com/reference/android/widget/ImageView)
+* [`CheckBox`](https://developer.android.com/reference/android/widget/CheckBox)
 
 
 The following example shows four images arranged in a two-by-two array with a favorite icon in the upper-right corner of each image.

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -124,6 +124,7 @@ The following example shows a toggle button with three buttons that have icons a
 
 !["Toggle bar example for Android displaying icons."](assets/toggle-buttons.svg)
 
+In the XML layout:
 ```xml
  <com.google.android.material.button.MaterialButtonToggleGroup
     android:id="@+id/toggleButton"
@@ -136,7 +137,8 @@ The following example shows a toggle button with three buttons that have icons a
         android:layout_height="wrap_content"
         android:minWidth="48dp"
         app:icon="@drawable/ic_favorite"
-        app:iconPadding="0dp" />
+        app:iconPadding="0dp"
+    />
     <Button
         android:id="@+id/removeRedEyeButton"
         style="?attr/materialButtonOutlinedStyle"
@@ -144,7 +146,8 @@ The following example shows a toggle button with three buttons that have icons a
         android:layout_height="wrap_content"
         android:minWidth="48dp"
         app:icon="@drawable/ic_remove_red_eye"
-        app:iconPadding="0dp" />
+        app:iconPadding="0dp"
+    />
     <Button
         android:id="@+id/notificationsButton"
         style="?attr/materialButtonOutlinedStyle"
@@ -152,11 +155,19 @@ The following example shows a toggle button with three buttons that have icons a
         android:layout_height="wrap_content"
         android:minWidth="48dp"
         app:icon="@drawable/ic_notifications"
-        app:iconPadding="0dp" />
+        app:iconPadding="0dp"
+    />
 </com.google.android.material.button.MaterialButtonToggleGroup>
 ```
 
 _**Note:** The example allows multiple buttons to be selected. If only one option in the group should be selected and active at a time, add `app:singleSelection="true"` to `MaterialButtonToggleGroup`. This ensures that selecting one option deselects any other._
+
+In code:
+```kt
+toggleButton.addOnButtonCheckedListener { toggleButton, checkedId, isChecked ->
+    // Do something for button toggle
+}
+```
 
 ### Icon
 
@@ -164,102 +175,45 @@ Icons can be used as toggle buttons when they allow selection, or deselection, o
 
 #### Icon example
 
-Source code APIs:
+Source code API:
 
-* [`RecyclerView`](https://developer.android.com/reference/androidx/recyclerview/widget/RecyclerView)
-* [`FrameLayout`](https://developer.android.com/reference/android/widget/FrameLayout)
-* [`ImageView`](https://developer.android.com/reference/android/widget/ImageView)
-* [`CheckBox`](https://developer.android.com/reference/android/widget/CheckBox)
+* `CheckBox`
+    * [Class description](https://developer.android.com/reference/android/widget/CheckBox)
 
-
-The following example shows four images arranged in a two-by-two array with a favorite icon in the upper-right corner of each image.
+The following example shows an icon that can be used independently or in items of a `RecyclerView`.
 
 <img src="assets/android_toggle_button.png" alt="Android toggle icon button example showing four images in an array with a favorite icon in the upper-right corner of each image.">
 
-This example separates out the image and checkbox (favorite icon) element into a separate layout xml file:
-[`image_grid_item_layout.xml`](toggle_demo/app/src/main/res/layout/image_grid_item_layout.xml).
-
+In the XML layout:
 ```xml
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/container"
-    android:layout_width="match_parent"
-    android:layout_height="200dp"
-    android:layout_margin="2dp"
-    android:foreground="?attr/selectableItemBackground">
-
-    <ImageView
-        android:id="@+id/image_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scaleType="centerCrop"
-        android:contentDescription="@string/image_content_desc"
-        tools:src="@drawable/img1"/>
-
-    <CheckBox
-        android:id="@+id/favorite_check_box"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:button="@drawable/favorite_state_list_drawable"
-        app:buttonTint="@android:color/white"
-        android:layout_gravity="top|end"
-        android:clickable="false"/>
-
-</FrameLayout>
+<CheckBox
+    android:id="@+id/icon"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:button="@drawable/sl_favourite"
+    app:buttonTint="@android:color/white"
+/>
 ```
 
-In a separate Kotlin file &mdash; [`ImageGridAdapater.kt`](toggle_demo/app/src/main/java/io/material/togglebuttons/ImageGridAdapter.kt), the `ImageGridAdapter` interates through a list of images in the `drawable` folder referenced in [`ImageItem.kt`](toggle_demo/app/src/main/java/io/material/togglebuttons/ImageItem.kt) as the `ImageView` backgrounds.
+In the `res/drawable/sl_favourite.xml` file:
+```xml
+<selector>
+    <item
+        android:drawable="@drawable/ic_favourite_outlined" 
+        android:state_checked="false"
+    />
+    <item
+        android:drawable="@drawable/ic_favourite_filled" 
+        android:state_checked="true"
+    />
+    <item android:drawable="@drawable/ic_favourite_outlined" />
+</selector>
+```
+
+In code:
 
 ```kt
-class ImageGridAdapter(
-    private val listener: Listener
-) : ListAdapter<ImageItem, ImageGridViewHolder>(ImageItemDiffCallback) {
-
-    interface Listener {
-        fun onItemClicked(item: ImageItem)
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageGridViewHolder {
-        return ImageGridViewHolder(
-            LayoutInflater.from(parent.context)
-                .inflate(R.layout.image_grid_item_layout, parent, false),
-            listener
-        )
-    }
-
-    override fun onBindViewHolder(holder: ImageGridViewHolder, position: Int) {
-        holder.bind(getItem(position))
-    }
+icon.setOnCheckedChangeListener { checkBox, isChecked ->
+    // Do something for icon toggle     
 }
-
-class ImageGridViewHolder(
-    view: View,
-    private val listener: ImageGridAdapter.Listener
-) : RecyclerView.ViewHolder(view) {
-    private val container = view.findViewById<FrameLayout>(R.id.container)
-    private val imageView = view.findViewById<ImageView>(R.id.image_view)
-    private val favoriteView = view.findViewById<CheckBox>(R.id.favorite_check_box)
-    fun bind(item: ImageItem) {
-        imageView.setImageResource(item.imageRes)
-        favoriteView.isChecked = item.isFavorite
-        container.setOnClickListener {
-            listener.onItemClicked(item)
-        }
-    }
-}
-```
-
-In the `actvity_main.xml` file, the list of images in arranged to fit into the `RecyclerView`:
-
-```xml
- <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/image_recycler_view"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:paddingTop="16dp"
-        app:layout_constraintTop_toBottomOf="@id/button_group"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
 ```

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -33,11 +33,11 @@ The following example shows a text button with purple text on a white background
 
 ```xml
     <Button
-        android:id="@+id/button3"
+        android:id="@+id/textButton"
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Text"
+        android:text="Text button"
         ...
     />
 ```
@@ -58,11 +58,11 @@ Source code API:
 
 ```xml
     <Button
-        android:id="@+id/button2"
+        android:id="@+id/outlinedButton"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Outlined"
+        android:text="Outlined button"
         ...
     />
 ```
@@ -86,14 +86,13 @@ The following example shows a contained button with white text on a purple backg
 
 ```xml
     <Button
-        android:id="@+id/button4"
+        android:id="@+id/containedButton"
         style="@style/Widget.MaterialComponents.Button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Contained"
+        android:text="Contained button"
         ...
     />
-
 ```
 
 ## Toggle button

--- a/button-examples/Android/android-button-example.md
+++ b/button-examples/Android/android-button-example.md
@@ -111,55 +111,52 @@ To emphasize groups of related toggle buttons, a group should share a common con
 
 #### Toggle button example
 
-The following example shows a toggle bar with the following icons:
-* aspect ratio
-* assignment
-* late assignment
-* bookmark
-
-The example allows multiple buttons to be selected. If only one option in the group should be selected and active at a time, add `app:singleSelection="true"` to `MaterialButtonToggleGroup`. This ensures that selecting one option deselects any other.
-
 Source code APIs:
-
-* `MaterialButton`
-    * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
-    * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
 
 * `MaterialButtonToggleGroup`
     * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButtonToggleGroup)
     * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButtonToggleGroup.java)
+* `MaterialButton`
+    * [Class description](https://developer.android.com/reference/com/google/android/material/button/MaterialButton)
+    * [GitHub source](https://github.com/material-components/material-components-android/blob/master/lib/java/com/google/android/material/button/MaterialButton.java)
+
+The following example shows a toggle button with three buttons that have icons and no text labels.
 
 !["Toggle bar example for Android displaying icons."](assets/toggle-buttons.svg)
 
 ```xml
  <com.google.android.material.button.MaterialButtonToggleGroup
-        android:id="@+id/button_group"
+    android:id="@+id/toggleButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+    <Button
+        android:id="@+id/favoriteButton"
+        style="?attr/materialButtonOutlinedStyle"    
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
-        <Button
-            style="?attr/materialButtonOutlinedIconStyle"
-            android:id="@+id/favorite_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_favorite" />
-        <Button
-            style="?attr/materialButtonOutlinedIconStyle"
-            android:id="@+id/remove_red_eye_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_remove_red_eye" />
-        <Button
-            style="?attr/materialButtonOutlinedIconStyle"
-            android:id="@+id/notifications_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:icon="@drawable/ic_notifications" />
-    </com.google.android.material.button.MaterialButtonToggleGroup>
-
+        android:minWidth="48dp"
+        app:icon="@drawable/ic_favorite"
+        app:iconPadding="0dp" />
+    <Button
+        android:id="@+id/removeRedEyeButton"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="48dp"
+        app:icon="@drawable/ic_remove_red_eye"
+        app:iconPadding="0dp" />
+    <Button
+        android:id="@+id/notificationsButton"
+        style="?attr/materialButtonOutlinedStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="48dp"
+        app:icon="@drawable/ic_notifications"
+        app:iconPadding="0dp" />
+</com.google.android.material.button.MaterialButtonToggleGroup>
 ```
+
+_**Note:** The example allows multiple buttons to be selected. If only one option in the group should be selected and active at a time, add `app:singleSelection="true"` to `MaterialButtonToggleGroup`. This ensures that selecting one option deselects any other._
 
 ### Icon
 


### PR DESCRIPTION
This PR is a proposal for a few changes to build on the great work already done:
- Updates the "Using buttons" wording a bit (eg. "the Material.io button" -> "Material buttons")
- Ensures code highlighting for any class mention
- Updates the naming of toggle button types to be: "toggle button" and "icon" (nowhere in the design guidance is there mention of a "toggle bar" or "toggle icon", but this is certainly up for discussion)
- Minor updates to formatting, wording, naming/IDs in examples, etc.
- Major updates to both toggle button examples in an attempt to: reduce verbosity where possible and focus on the core component as opposed to the supporting elements.